### PR TITLE
Added LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2026 Black Ledger Interactive, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
# Summary

Add a standard MIT LICENSE file to the .github repository.

# Motivation

Although this repository only contains GitHub configuration and documentation, it should still clearly define reuse and distribution terms.

Adding a LICENSE aligns this repo with the rest of the organization and avoids ambiguity for contributors or downstream users.

# What’s Included
- Standard MIT License text
- Copyright attributed to Black Ledger Interactive, LLC

# Scope Notes
- License applies only to the contents of this repository
- No game code, assets, or proprietary systems are covered here
- No custom clauses or restrictions added

Related
- Closes: #5 
